### PR TITLE
Original infnet remaining configs

### DIFF
--- a/model_configs/multilabel_classification/v2.5/bibtex_strat_margin_l1_tasknn.jsonnet
+++ b/model_configs/multilabel_classification/v2.5/bibtex_strat_margin_l1_tasknn.jsonnet
@@ -1,0 +1,196 @@
+local test = std.extVar('TEST');  // a test run with small dataset
+local data_dir = std.extVar('DATA_DIR');
+local cuda_device = std.extVar('CUDA_DEVICE');
+local use_wandb = (if test == '1' then false else true);
+
+local dataset_name = 'bibtex_strat';
+local dataset_metadata = (import '../datasets.jsonnet')[dataset_name];
+local num_labels = dataset_metadata.num_labels;
+local num_input_features = dataset_metadata.input_features;
+
+// model variables
+local ff_hidden = std.parseJson(std.extVar('ff_hidden'));
+local label_space_dim = ff_hidden;
+local ff_dropout = std.parseJson(std.extVar('ff_dropout'));
+local ff_activation = 'softplus';
+local ff_linear_layers = std.parseJson(std.extVar('ff_linear_layers'));
+local ff_weight_decay = std.parseJson(std.extVar('ff_weight_decay'));
+local global_score_hidden_dim = std.parseJson(std.extVar('global_score_hidden_dim'));
+local gain = (if ff_activation == 'tanh' then 5 / 3 else 1);
+local cross_entropy_loss_weight = std.parseJson(std.extVar('cross_entropy_loss_weight'));
+local inference_score_weight = std.parseJson(std.extVar('inference_score_weight'));
+{
+  [if use_wandb then 'type']: 'train_test_log_to_wandb',
+  evaluate_on_test: true,
+  // Data
+  dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  validation_dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  train_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                    dataset_metadata.train_file),
+  validation_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                         dataset_metadata.validation_file),
+  test_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                   dataset_metadata.test_file),
+
+  // Model
+  model: {
+    type: 'multi-label-classification-with-infnet',
+    sampler: {
+      type: 'appending-container',
+      log_key: 'sampler',
+      constituent_samplers: [],
+    },
+    task_nn: {
+      type: 'multi-label-classification',
+      feature_network: {
+        input_dim: num_input_features,
+        num_layers: ff_linear_layers,
+        activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+        hidden_dims: ff_hidden,
+        dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+      },
+      label_embeddings: {
+        embedding_dim: ff_hidden,
+        vocab_namespace: 'labels',
+      },
+    },
+
+    inference_module: {
+      type: 'multi-label-inference-net-normalized',
+      log_key: 'inference_module',
+      cost_augmented_layer: {
+        type: 'multi-label-stacked',
+        feedforward: {
+          input_dim: 2 * num_labels,
+          num_layers: 2,
+          activations: [ff_activation, 'linear'],
+          hidden_dims: num_labels,
+        },
+        normalize_y: true,
+      },
+      loss_fn: {
+        type: 'combination-loss',
+        log_key: 'loss',
+        constituent_losses: [
+          {
+            type: 'multi-label-inference',
+            log_key: 'neg_inference',
+            normalize_y: true,
+            reduction: 'none',
+            inference_score_weight: inference_score_weight,
+          },  //This loss can be different from the main loss // change this
+          {
+            type: 'multi-label-bce',
+            reduction: 'none',
+            log_key: 'bce',
+          },
+        ],
+        loss_weights: [1.0, cross_entropy_loss_weight],
+        reduction: 'mean',
+      },
+    },
+    oracle_value_function: {
+      type: 'manhattan',
+      differentiable: true,
+    },
+    score_nn: {
+      type: 'multi-label-classification',
+      task_nn: {
+        type: 'multi-label-classification',
+        feature_network: {
+          input_dim: num_input_features,
+          num_layers: ff_linear_layers,
+          activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+          hidden_dims: ff_hidden,
+          dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+        },
+        label_embeddings: {
+          embedding_dim: ff_hidden,
+          vocab_namespace: 'labels',
+        },
+      },
+      global_score: {
+        type: 'multi-label-feedforward',
+        feedforward: {
+          input_dim: num_labels,
+          num_layers: 1,
+          activations: ff_activation,
+          hidden_dims: global_score_hidden_dim,
+        },
+      },
+    },
+    loss_fn: {
+      type: 'multi-label-margin-based',
+      oracle_cost_weight: 1.0,
+      perceptron_loss_weight: inference_score_weight,
+      reduction: 'mean',
+      log_key: 'margin_loss',
+    },
+    initializer: {
+      regexes: [
+        //[@'.*_feedforward._linear_layers.0.weight', {type: 'normal'}],
+        [@'.*_linear_layers.*weight', (if std.member(['tanh', 'sigmoid'], ff_activation) then { type: 'xavier_uniform', gain: gain } else { type: 'kaiming_uniform', nonlinearity: 'relu' })],
+        [@'.*linear_layers.*bias', { type: 'zero' }],
+      ],
+    },
+  },
+  data_loader: {
+    shuffle: true,
+    batch_size: 32,
+  },
+  trainer: {
+    type: 'gradient_descent_minimax',
+    num_epochs: if test == '1' then 10 else 300,
+    grad_norm: { task_nn: 10.0 },
+    patience: 20,
+    validation_metric: '+fixed_f1',
+    cuda_device: std.parseInt(cuda_device),
+    learning_rate_schedulers: {
+      task_nn: {
+        type: 'reduce_on_plateau',
+        factor: 0.5,
+        mode: 'max',
+        patience: 5,
+        verbose: true,
+      },
+    },
+    optimizer: {
+      optimizers: {
+        task_nn:
+          {
+            lr: 0.001,
+            weight_decay: ff_weight_decay,
+            type: 'adamw',
+          },
+        score_nn: {
+          lr: 0.005,
+          weight_decay: ff_weight_decay,
+          type: 'adamw',
+        },
+      },
+    },
+    checkpointer: {
+      keep_most_recent_by_count: 1,
+    },
+    callbacks: [
+      'track_epoch_callback',
+      'slurm',
+    ] + (
+      if use_wandb then [
+        {
+          type: 'wandb_allennlp',
+          sub_callbacks: [{ type: 'log_best_validation_metrics', priority: 100 }],
+        },
+      ]
+      else []
+    ),
+    inner_mode: 'task_nn',
+    num_steps: { task_nn: 1, score_nn: 1 },
+  },
+}

--- a/model_configs/multilabel_classification/v2.5/bibtex_strat_tasknn.jsonnet
+++ b/model_configs/multilabel_classification/v2.5/bibtex_strat_tasknn.jsonnet
@@ -1,0 +1,175 @@
+local test = std.extVar('TEST');  // a test run with small dataset
+local data_dir = std.extVar('DATA_DIR');
+local cuda_device = std.extVar('CUDA_DEVICE');
+local use_wandb = (if test == '1' then false else true);
+
+local dataset_name = 'bibtex_strat';
+local dataset_metadata = (import '../datasets.jsonnet')[dataset_name];
+local num_labels = dataset_metadata.num_labels;
+local num_input_features = dataset_metadata.input_features;
+
+// model variables
+local ff_hidden = std.parseJson(std.extVar('ff_hidden'));
+local label_space_dim = ff_hidden;
+local ff_dropout = std.parseJson(std.extVar('ff_dropout_10x')) / 10.0;
+local ff_activation = 'softplus';
+local ff_linear_layers = std.parseJson(std.extVar('ff_linear_layers'));
+local ff_weight_decay = std.parseJson(std.extVar('ff_weight_decay'));
+local global_score_hidden_dim = std.parseJson(std.extVar('global_score_hidden_dim'));
+local gain = (if ff_activation == 'tanh' then 5 / 3 else 1);
+local cross_entropy_loss_weight = std.parseJson(std.extVar('cross_entropy_loss_weight'));
+local dvn_score_loss_weight = std.parseJson(std.extVar('dvn_score_loss_weight'));
+{
+  [if use_wandb then 'type']: 'train_test_log_to_wandb',
+  evaluate_on_test: true,
+  // Data
+  dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  validation_dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  train_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                    dataset_metadata.train_file),
+  validation_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                         dataset_metadata.validation_file),
+  test_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                   dataset_metadata.test_file),
+
+  // Model
+  model: {
+    type: 'multi-label-classification-with-infnet',
+    sampler: {
+      type: 'appending-container',
+      log_key: 'sampler',
+      constituent_samplers: [],
+    },
+    task_nn: {
+      type: 'multi-label-classification',
+      feature_network: {
+        input_dim: num_input_features,
+        num_layers: ff_linear_layers,
+        activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+        hidden_dims: ff_hidden,
+        dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+      },
+      label_embeddings: {
+        embedding_dim: ff_hidden,
+        vocab_namespace: 'labels',
+      },
+    },
+    inference_module: {
+      type: 'multi-label-inference-net-normalized',
+      log_key: 'inference_module',
+      loss_fn: {
+        type: 'combination-loss',
+        log_key: 'loss',
+        constituent_losses: [
+          {
+            type: 'multi-label-dvn-score',
+            log_key: 'neg.dvn_score',
+            normalize_y: true,
+            reduction: 'none',
+          },  //This loss can be different from the main loss // change this
+          {
+            type: 'multi-label-bce',
+            reduction: 'none',
+            log_key: 'bce',
+          },
+        ],
+        loss_weights: [0, cross_entropy_loss_weight],
+        reduction: 'mean',
+      },
+    },
+    oracle_value_function: { type: 'per-instance-f1', differentiable: false },
+    score_nn: {
+      type: 'multi-label-classification',
+      task_nn: {
+        type: 'multi-label-classification',
+        feature_network: {
+          input_dim: num_input_features,
+          num_layers: ff_linear_layers,
+          activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+          hidden_dims: ff_hidden,
+          dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+        },
+        label_embeddings: {
+          embedding_dim: ff_hidden,
+          vocab_namespace: 'labels',
+        },
+      },
+      global_score: {
+        type: 'multi-label-feedforward',
+        feedforward: {
+          input_dim: num_labels,
+          num_layers: 1,
+          activations: ff_activation,
+          hidden_dims: global_score_hidden_dim,
+        },
+      },
+    },
+    loss_fn: { type: 'multi-label-dvn-bce', log_key: 'dvn_bce' },
+    initializer: {
+      regexes: [
+        //[@'.*_feedforward._linear_layers.0.weight', {type: 'normal'}],
+        [@'.*_linear_layers.*weight', (if std.member(['tanh', 'sigmoid'], ff_activation) then { type: 'xavier_uniform', gain: gain } else { type: 'kaiming_uniform', nonlinearity: 'relu' })],
+        [@'.*linear_layers.*bias', { type: 'zero' }],
+      ],
+    },
+  },
+  data_loader: {
+    shuffle: true,
+    batch_size: 32,
+  },
+  trainer: {
+    type: 'gradient_descent_minimax',
+    num_epochs: if test == '1' then 10 else 300,
+    grad_norm: { task_nn: 10.0 },
+    patience: 20,
+    validation_metric: '+fixed_f1',
+    cuda_device: std.parseInt(cuda_device),
+    learning_rate_schedulers: {
+      task_nn: {
+        type: 'reduce_on_plateau',
+        factor: 0.5,
+        mode: 'max',
+        patience: 5,
+        verbose: true,
+      },
+    },
+    optimizer: {
+      optimizers: {
+        task_nn:
+          {
+            lr: 0.001,
+            weight_decay: ff_weight_decay,
+            type: 'adamw',
+          },
+        score_nn: {
+          lr: 0.005,
+          weight_decay: ff_weight_decay,
+          type: 'adamw',
+        },
+      },
+    },
+    checkpointer: {
+      keep_most_recent_by_count: 1,
+    },
+    callbacks: [
+      'track_epoch_callback',
+      'slurm',
+    ] + (
+      if use_wandb then [
+        {
+          type: 'wandb_allennlp',
+          sub_callbacks: [{ type: 'log_best_validation_metrics', priority: 100 }],
+        },
+      ]
+      else []
+    ),
+    inner_mode: 'score_nn',
+    num_steps: { task_nn: 1, score_nn: 1 },
+  },
+}

--- a/sweep_configs/multilabel_classification/v2.5/bibtex_strat_margin_l1_tasknn.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/bibtex_strat_margin_l1_tasknn.yaml
@@ -1,0 +1,52 @@
+name: bibtex_strat_margin_l1_tasknn
+description: "Train tasknn using cross-entropy and inference score loss (as in Tu & Gimpel). The score-nn will be trained using margin based loss with cost augmented network. There is no sampling in this version"
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/bibtex_strat_margin_l1_tasknn.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,score_nn_loss=margin,task_nn_loss=bce+inference_score,sampler=inference_net,dataset=bibtex_strat,inference_module=inference_net,inference_module=tasknn,inference_module_loss=bce+inference_score,sampler=tasknn"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.cross_entropy_loss_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.inference_score_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.ff_dropout:
+    value: 0.5
+  env.ff_hidden:
+    value: 400
+  env.ff_linear_layers:
+    value: 2
+  env.ff_weight_decay:
+    value: 0.00001
+  env.global_score_hidden_dim:
+    value: 200
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  trainer.optimizer.optimizers.score_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  trainer.num_steps.task_nn:
+    distribution: q_uniform
+    min: 3
+    max: 11
+    q: 3

--- a/sweep_configs/multilabel_classification/v2.5/bibtex_strat_tasknn.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/bibtex_strat_tasknn.yaml
@@ -1,0 +1,53 @@
+name: bibtex_strat_tasknn
+description: "Train tasknn using cross-entropy only"
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/bibtex_strat_tasknn.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,model=tasknn,sampler=none,dataset=bibtex_strat,inference_module=tasknn,sampler=none,ref=7tvr5xhg"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.cross_entropy_loss_weight:
+    value: 1.0
+  env.dvn_score_loss_weight:
+    value: 0.0
+  env.ff_dropout_10x:
+    distribution: q_uniform
+    max: 70
+    min: 0
+    q: 10
+  env.ff_hidden:
+    distribution: q_uniform
+    max: 400
+    min: 200
+    q: 100
+  env.ff_linear_layers:
+    distribution: int_uniform
+    max: 4
+    min: 1
+  env.ff_weight_decay:
+    distribution: log_uniform
+    max: -4.5
+    min: -15.0
+  env.global_score_hidden_dim:
+    value: 200
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5 
+  trainer.optimizer.optimizers.score_nn.lr:
+    value: 0.001
+  trainer.num_steps.score_nn:
+    value: 1


### PR DESCRIPTION
The previous PR only included configs for original infnet with reverse order. In this PR, I have added the configs for the original order (inner loop=infnet, outer loop=Energy). Additionally, this PR also adds a config of basic tasknn only model.
