### PR TITLE
Pushing general sweep configs & corresponding jsonnet. + Sweep configs for 'delicious' dataset.

### DIFF
--- a/model_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_reverse.jsonnet
+++ b/model_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_reverse.jsonnet
@@ -1,0 +1,179 @@
+local test = std.extVar('TEST');  // a test run with small dataset
+local data_dir = std.extVar('DATA_DIR');
+local cuda_device = std.extVar('CUDA_DEVICE');
+local use_wandb = (if test == '1' then false else true);
+
+local dataset_name = 'bibtex_strat';
+local dataset_metadata = (import '../datasets.jsonnet')[dataset_name];
+local num_labels = dataset_metadata.num_labels;
+local num_input_features = dataset_metadata.input_features;
+
+// model variables
+local ff_hidden = std.parseJson(std.extVar('ff_hidden'));
+local label_space_dim = ff_hidden;
+local ff_dropout = std.parseJson(std.extVar('ff_dropout_10x')) / 10.0;
+local ff_activation = 'softplus';
+local ff_linear_layers = std.parseJson(std.extVar('ff_linear_layers'));
+local ff_weight_decay = std.parseJson(std.extVar('ff_weight_decay'));
+local global_score_hidden_dim = std.parseJson(std.extVar('global_score_hidden_dim'));
+local gain = (if ff_activation == 'tanh' then 5 / 3 else 1);
+local cross_entropy_loss_weight = std.parseJson(std.extVar('cross_entropy_loss_weight'));
+local dvn_score_loss_weight = std.parseJson(std.extVar('dvn_score_loss_weight'));
+local task_temp = std.parseJson(std.extVar('task_nn_steps')); # variable for task_nn.steps
+local task_nn_steps = (if std.toString(task_temp) == '0' then 1 else task_temp);
+local score_temp = std.parseJson(std.extVar('score_nn_steps')); # variable for score_nn.steps
+local score_nn_steps = (if std.toString(score_temp) == '0' then 1 else score_temp);
+{
+  [if use_wandb then 'type']: 'train_test_log_to_wandb',
+  evaluate_on_test: true,
+  // Data
+  dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  validation_dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  train_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                    dataset_metadata.train_file),
+  validation_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                         dataset_metadata.validation_file),
+  test_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                   dataset_metadata.test_file),
+
+  // Model
+  model: {
+    type: 'multi-label-classification-with-infnet',
+    sampler: {
+      type: 'appending-container',
+      log_key: 'sampler',
+      constituent_samplers: [],
+    },
+    task_nn: {
+      type: 'multi-label-classification',
+      feature_network: {
+        input_dim: num_input_features,
+        num_layers: ff_linear_layers,
+        activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+        hidden_dims: ff_hidden,
+        dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+      },
+      label_embeddings: {
+        embedding_dim: ff_hidden,
+        vocab_namespace: 'labels',
+      },
+    },
+    inference_module: {
+      type: 'multi-label-inference-net-normalized',
+      log_key: 'inference_module',
+      loss_fn: {
+        type: 'combination-loss',
+        log_key: 'loss',
+        constituent_losses: [
+          {
+            type: 'multi-label-dvn-score',
+            log_key: 'neg.dvn_score',
+            normalize_y: true,
+            reduction: 'none',
+          },  //This loss can be different from the main loss // change this
+          {
+            type: 'multi-label-bce',
+            reduction: 'none',
+            log_key: 'bce',
+          },
+        ],
+        loss_weights: [dvn_score_loss_weight, cross_entropy_loss_weight],
+        reduction: 'mean',
+      },
+    },
+    oracle_value_function: { type: 'per-instance-f1', differentiable: false },
+    score_nn: {
+      type: 'multi-label-classification',
+      task_nn: {
+        type: 'multi-label-classification',
+        feature_network: {
+          input_dim: num_input_features,
+          num_layers: ff_linear_layers,
+          activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+          hidden_dims: ff_hidden,
+          dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+        },
+        label_embeddings: {
+          embedding_dim: ff_hidden,
+          vocab_namespace: 'labels',
+        },
+      },
+      global_score: {
+        type: 'multi-label-feedforward',
+        feedforward: {
+          input_dim: num_labels,
+          num_layers: 1,
+          activations: ff_activation,
+          hidden_dims: global_score_hidden_dim,
+        },
+      },
+    },
+    loss_fn: { type: 'multi-label-dvn-bce', log_key: 'dvn_bce' },
+    initializer: {
+      regexes: [
+        //[@'.*_feedforward._linear_layers.0.weight', {type: 'normal'}],
+        [@'.*_linear_layers.*weight', (if std.member(['tanh', 'sigmoid'], ff_activation) then { type: 'xavier_uniform', gain: gain } else { type: 'kaiming_uniform', nonlinearity: 'relu' })],
+        [@'.*linear_layers.*bias', { type: 'zero' }],
+      ],
+    },
+  },
+  data_loader: {
+    shuffle: true,
+    batch_size: 32,
+  },
+  trainer: {
+    type: 'gradient_descent_minimax',
+    num_epochs: if test == '1' then 10 else 300,
+    grad_norm: { task_nn: 10.0 },
+    patience: 20,
+    validation_metric: '+fixed_f1',
+    cuda_device: std.parseInt(cuda_device),
+    learning_rate_schedulers: {
+      task_nn: {
+        type: 'reduce_on_plateau',
+        factor: 0.5,
+        mode: 'max',
+        patience: 5,
+        verbose: true,
+      },
+    },
+    optimizer: {
+      optimizers: {
+        task_nn:
+          {
+            lr: 0.001,
+            weight_decay: ff_weight_decay,
+            type: 'adamw',
+          },
+        score_nn: {
+          lr: 0.005,
+          weight_decay: ff_weight_decay,
+          type: 'adamw',
+        },
+      },
+    },
+    checkpointer: {
+      keep_most_recent_by_count: 1,
+    },
+    callbacks: [
+      'track_epoch_callback',
+      'slurm',
+    ] + (
+      if use_wandb then [
+        {
+          type: 'wandb_allennlp',
+          sub_callbacks: [{ type: 'log_best_validation_metrics', priority: 100 }],
+        },
+      ]
+      else []
+    ),
+    inner_mode: 'score_nn',
+    num_steps: { task_nn: task_nn_steps, score_nn: score_nn_steps },
+  },
+}

--- a/model_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_samples_reverse.jsonnet
+++ b/model_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_samples_reverse.jsonnet
@@ -1,0 +1,182 @@
+local test = std.extVar('TEST');  // a test run with small dataset
+local data_dir = std.extVar('DATA_DIR');
+local cuda_device = std.extVar('CUDA_DEVICE');
+local use_wandb = (if test == '1' then false else true);
+
+local dataset_name = std.parseJson(std.extVar('dataset_name'));
+local dataset_metadata = (import '../datasets.jsonnet')[dataset_name];
+local num_labels = dataset_metadata.num_labels;
+local num_input_features = dataset_metadata.input_features;
+
+// model variables
+local ff_hidden = std.parseJson(std.extVar('ff_hidden'));
+local label_space_dim = ff_hidden;
+local ff_dropout = std.parseJson(std.extVar('ff_dropout_10x')) / 10.0;
+local ff_activation = 'softplus';
+local ff_linear_layers = std.parseJson(std.extVar('ff_linear_layers'));
+local ff_weight_decay = std.parseJson(std.extVar('ff_weight_decay'));
+local global_score_hidden_dim = std.parseJson(std.extVar('global_score_hidden_dim'));
+local gain = (if ff_activation == 'tanh' then 5 / 3 else 1);
+local cross_entropy_loss_weight = std.parseJson(std.extVar('cross_entropy_loss_weight'));
+local dvn_score_loss_weight = std.parseJson(std.extVar('dvn_score_loss_weight'));
+local task_temp = std.parseJson(std.extVar('task_nn_steps')); # variable for task_nn.steps
+local task_nn_steps = (if std.toString(task_temp) == '0' then 1 else task_temp);
+local score_temp = std.parseJson(std.extVar('score_nn_steps')); # variable for score_nn.steps
+local score_nn_steps = (if std.toString(score_temp) == '0' then 1 else score_temp);
+{
+  [if use_wandb then 'type']: 'train_test_log_to_wandb',
+  evaluate_on_test: true,
+  // Data
+  dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  validation_dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  train_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                    dataset_metadata.train_file),
+  validation_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                         dataset_metadata.validation_file),
+  test_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                   dataset_metadata.test_file),
+
+  // Model
+  model: {
+    type: 'multi-label-classification-with-infnet',
+    sampler: {
+      type: 'appending-container',
+      log_key: 'sampler',
+      constituent_samplers: [],
+    },
+    task_nn: {
+      type: 'multi-label-classification',
+      feature_network: {
+        input_dim: num_input_features,
+        num_layers: ff_linear_layers,
+        activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+        hidden_dims: ff_hidden,
+        dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+      },
+      label_embeddings: {
+        embedding_dim: ff_hidden,
+        vocab_namespace: 'labels',
+      },
+    },
+    inference_module: {
+      type: 'multi-label-inference-net-normalized-or-continuous-sampled',
+      log_key: 'inference_module',
+      keep_probs: true,
+      num_samples: 20,
+      std: 0.5,
+      loss_fn: {
+        type: 'combination-loss',
+        log_key: 'loss',
+        constituent_losses: [
+          {
+            type: 'multi-label-dvn-score',
+            log_key: 'neg.dvn_score',
+            normalize_y: true,
+            reduction: 'none',
+          },  //This loss can be different from the main loss // change this
+          {
+            type: 'multi-label-bce',
+            reduction: 'none',
+            log_key: 'bce',
+          },
+        ],
+        loss_weights: [dvn_score_loss_weight, cross_entropy_loss_weight],
+        reduction: 'mean',
+      },
+    },
+    oracle_value_function: { type: 'per-instance-f1', differentiable: false },
+    score_nn: {
+      type: 'multi-label-classification',
+      task_nn: {
+        type: 'multi-label-classification',
+        feature_network: {
+          input_dim: num_input_features,
+          num_layers: ff_linear_layers,
+          activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+          hidden_dims: ff_hidden,
+          dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+        },
+        label_embeddings: {
+          embedding_dim: ff_hidden,
+          vocab_namespace: 'labels',
+        },
+      },
+      global_score: {
+        type: 'multi-label-feedforward',
+        feedforward: {
+          input_dim: num_labels,
+          num_layers: 1,
+          activations: ff_activation,
+          hidden_dims: global_score_hidden_dim,
+        },
+      },
+    },
+    loss_fn: { type: 'multi-label-dvn-bce', log_key: 'dvn_bce' },
+    initializer: {
+      regexes: [
+        //[@'.*_feedforward._linear_layers.0.weight', {type: 'normal'}],
+        [@'.*_linear_layers.*weight', (if std.member(['tanh', 'sigmoid'], ff_activation) then { type: 'xavier_uniform', gain: gain } else { type: 'kaiming_uniform', nonlinearity: 'relu' })],
+        [@'.*linear_layers.*bias', { type: 'zero' }],
+      ],
+    },
+  },
+  data_loader: {
+    shuffle: true,
+    batch_size: 32,
+  },
+  trainer: {
+    type: 'gradient_descent_minimax',
+    num_epochs: if test == '1' then 10 else 300,
+    grad_norm: { task_nn: 10.0 },
+    patience: 20,
+    validation_metric: '+fixed_f1',
+    cuda_device: std.parseInt(cuda_device),
+    learning_rate_schedulers: {
+      task_nn: {
+        type: 'reduce_on_plateau',
+        factor: 0.5,
+        mode: 'max',
+        patience: 5,
+        verbose: true,
+      },
+    },
+    optimizer: {
+      optimizers: {
+        task_nn:
+          {
+            lr: 0.001,
+            weight_decay: ff_weight_decay,
+            type: 'adamw',
+          },
+        score_nn: {
+          lr: 0.005,
+          weight_decay: ff_weight_decay,
+          type: 'adamw',
+        },
+      },
+    },
+    checkpointer: {
+      keep_most_recent_by_count: 1,
+    },
+    callbacks: [
+      'track_epoch_callback',
+      'slurm',
+    ] + (
+      if use_wandb then [
+        {
+          type: 'wandb_allennlp',
+          sub_callbacks: [{ type: 'log_best_validation_metrics', priority: 100 }],
+        },
+      ]
+      else []
+    ),
+    inner_mode: 'score_nn',
+    num_steps: { task_nn: task_nn_steps, score_nn: score_nn_steps },
+  },
+}

--- a/model_configs/multilabel_classification/v2.5/gendata_nce_cont_tasknn_reverse.jsonnet
+++ b/model_configs/multilabel_classification/v2.5/gendata_nce_cont_tasknn_reverse.jsonnet
@@ -1,0 +1,185 @@
+local test = std.extVar('TEST');  // a test run with small dataset
+local data_dir = std.extVar('DATA_DIR');
+local cuda_device = std.extVar('CUDA_DEVICE');
+local use_wandb = (if test == '1' then false else true);
+
+local dataset_name = std.parseJson(std.extVar('dataset_name'));
+local dataset_metadata = (import '../datasets.jsonnet')[dataset_name];
+local num_labels = dataset_metadata.num_labels;
+local num_input_features = dataset_metadata.input_features;
+
+// model variables
+local ff_hidden = std.parseJson(std.extVar('ff_hidden'));
+local label_space_dim = ff_hidden;
+local ff_dropout = std.parseJson(std.extVar('ff_dropout_10x')) / 10.0;
+local ff_activation = 'softplus';
+local ff_linear_layers = std.parseJson(std.extVar('ff_linear_layers'));
+local ff_weight_decay = std.parseJson(std.extVar('ff_weight_decay'));
+local global_score_hidden_dim = std.parseJson(std.extVar('global_score_hidden_dim'));
+local gain = (if ff_activation == 'tanh' then 5 / 3 else 1);
+local cross_entropy_loss_weight = std.parseJson(std.extVar('cross_entropy_loss_weight'));
+local dvn_score_loss_weight = std.parseJson(std.extVar('dvn_score_loss_weight'));
+local task_temp = std.parseJson(std.extVar('task_nn_steps')); # variable for task_nn.steps
+local task_nn_steps = (if std.toString(task_temp) == '0' then 1 else task_temp);
+local score_temp = std.parseJson(std.extVar('score_nn_steps')); # variable for score_nn.steps
+local score_nn_steps = (if std.toString(score_temp) == '0' then 1 else score_temp);
+{
+  [if use_wandb then 'type']: 'train_test_log_to_wandb',
+  evaluate_on_test: true,
+  // Data
+  dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  validation_dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  train_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                    dataset_metadata.train_file),
+  validation_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                         dataset_metadata.validation_file),
+  test_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                   dataset_metadata.test_file),
+
+  // Model
+  model: {
+    type: 'multi-label-classification-with-infnet',
+    sampler: {
+      type: 'appending-container',
+      log_key: 'sampler',
+      constituent_samplers: [],
+    },
+    task_nn: {
+      type: 'multi-label-classification',
+      feature_network: {
+        input_dim: num_input_features,
+        num_layers: ff_linear_layers,
+        activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+        hidden_dims: ff_hidden,
+        dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+      },
+      label_embeddings: {
+        embedding_dim: ff_hidden,
+        vocab_namespace: 'labels',
+      },
+    },
+    inference_module: {
+      type: 'multi-label-inference-net-normalized',
+      log_key: 'inference_module',
+      loss_fn: {
+        type: 'combination-loss',
+        log_key: 'loss',
+        constituent_losses: [
+          {
+            type: 'multi-label-score-loss',
+            log_key: 'neg.nce_score',
+            normalize_y: true,
+            reduction: 'none',
+          },  //This loss can be different from the main loss // change this
+          {
+            type: 'multi-label-bce',
+            reduction: 'none',
+            log_key: 'bce',
+          },
+        ],
+        loss_weights: [dvn_score_loss_weight, cross_entropy_loss_weight],
+        reduction: 'mean',
+      },
+    },
+    oracle_value_function: { type: 'per-instance-f1', differentiable: false },
+    score_nn: {
+      type: 'multi-label-classification',
+      task_nn: {
+        type: 'multi-label-classification',
+        feature_network: {
+          input_dim: num_input_features,
+          num_layers: ff_linear_layers,
+          activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+          hidden_dims: ff_hidden,
+          dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+        },
+        label_embeddings: {
+          embedding_dim: ff_hidden,
+          vocab_namespace: 'labels',
+        },
+      },
+      global_score: {
+        type: 'multi-label-feedforward',
+        feedforward: {
+          input_dim: num_labels,
+          num_layers: 1,
+          activations: ff_activation,
+          hidden_dims: global_score_hidden_dim,
+        },
+      },
+    },
+    loss_fn: {
+      type: 'multi-label-nce-ranking-with-cont-sampling',
+      log_key: 'nce',
+      num_samples: 10,
+      sign: '+',
+      std: 10.0,
+    },
+    initializer: {
+      regexes: [
+        //[@'.*_feedforward._linear_layers.0.weight', {type: 'normal'}],
+        [@'.*_linear_layers.*weight', (if std.member(['tanh', 'sigmoid'], ff_activation) then { type: 'xavier_uniform', gain: gain } else { type: 'kaiming_uniform', nonlinearity: 'relu' })],
+        [@'.*linear_layers.*bias', { type: 'zero' }],
+      ],
+    },
+  },
+  data_loader: {
+    shuffle: true,
+    batch_size: 32,
+  },
+  trainer: {
+    type: 'gradient_descent_minimax',
+    num_epochs: if test == '1' then 10 else 300,
+    grad_norm: { task_nn: 10.0 },
+    patience: 20,
+    validation_metric: '+fixed_f1',
+    cuda_device: std.parseInt(cuda_device),
+    learning_rate_schedulers: {
+      task_nn: {
+        type: 'reduce_on_plateau',
+        factor: 0.5,
+        mode: 'max',
+        patience: 5,
+        verbose: true,
+      },
+    },
+    optimizer: {
+      optimizers: {
+        task_nn:
+          {
+            lr: 0.001,
+            weight_decay: ff_weight_decay,
+            type: 'adamw',
+          },
+        score_nn: {
+          lr: 0.005,
+          weight_decay: ff_weight_decay,
+          type: 'adamw',
+        },
+      },
+    },
+    checkpointer: {
+      keep_most_recent_by_count: 1,
+    },
+    callbacks: [
+      'track_epoch_callback',
+      'slurm',
+    ] + (
+      if use_wandb then [
+        {
+          type: 'wandb_allennlp',
+          sub_callbacks: [{ type: 'log_best_validation_metrics', priority: 100 }],
+        },
+      ]
+      else []
+    ),
+    inner_mode: 'score_nn',
+    num_steps: { task_nn: task_nn_steps, score_nn: score_nn_steps },
+  },
+}

--- a/model_configs/multilabel_classification/v2.5/gendata_nce_discrete_tasknn_reverse.jsonnet
+++ b/model_configs/multilabel_classification/v2.5/gendata_nce_discrete_tasknn_reverse.jsonnet
@@ -1,0 +1,184 @@
+local test = std.extVar('TEST');  // a test run with small dataset
+local data_dir = std.extVar('DATA_DIR');
+local cuda_device = std.extVar('CUDA_DEVICE');
+local use_wandb = (if test == '1' then false else true);
+
+local dataset_name = std.parseJson(std.extVar('dataset_name'));
+local dataset_metadata = (import '../datasets.jsonnet')[dataset_name];
+local num_labels = dataset_metadata.num_labels;
+local num_input_features = dataset_metadata.input_features;
+
+// model variables
+local ff_hidden = std.parseJson(std.extVar('ff_hidden'));
+local label_space_dim = ff_hidden;
+local ff_dropout = std.parseJson(std.extVar('ff_dropout_10x')) / 10.0;
+local ff_activation = 'softplus';
+local ff_linear_layers = std.parseJson(std.extVar('ff_linear_layers'));
+local ff_weight_decay = std.parseJson(std.extVar('ff_weight_decay'));
+local global_score_hidden_dim = std.parseJson(std.extVar('global_score_hidden_dim'));
+local gain = (if ff_activation == 'tanh' then 5 / 3 else 1);
+local cross_entropy_loss_weight = std.parseJson(std.extVar('cross_entropy_loss_weight'));
+local dvn_score_loss_weight = std.parseJson(std.extVar('dvn_score_loss_weight'));
+local task_temp = std.parseJson(std.extVar('task_nn_steps')); # variable for task_nn.steps
+local task_nn_steps = (if std.toString(task_temp) == '0' then 1 else task_temp);
+local score_temp = std.parseJson(std.extVar('score_nn_steps')); # variable for score_nn.steps
+local score_nn_steps = (if std.toString(score_temp) == '0' then 1 else score_temp);
+{
+  [if use_wandb then 'type']: 'train_test_log_to_wandb',
+  evaluate_on_test: true,
+  // Data
+  dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  validation_dataset_reader: {
+    type: 'arff',
+    num_labels: num_labels,
+  },
+  train_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                    dataset_metadata.train_file),
+  validation_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                         dataset_metadata.validation_file),
+  test_data_path: (data_dir + '/' + dataset_metadata.dir_name + '/' +
+                   dataset_metadata.test_file),
+
+  // Model
+  model: {
+    type: 'multi-label-classification-with-infnet',
+    sampler: {
+      type: 'appending-container',
+      log_key: 'sampler',
+      constituent_samplers: [],
+    },
+    task_nn: {
+      type: 'multi-label-classification',
+      feature_network: {
+        input_dim: num_input_features,
+        num_layers: ff_linear_layers,
+        activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+        hidden_dims: ff_hidden,
+        dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+      },
+      label_embeddings: {
+        embedding_dim: ff_hidden,
+        vocab_namespace: 'labels',
+      },
+    },
+    inference_module: {
+      type: 'multi-label-inference-net-normalized',
+      log_key: 'inference_module',
+      loss_fn: {
+        type: 'combination-loss',
+        log_key: 'loss',
+        constituent_losses: [
+          {
+            type: 'multi-label-score-loss',
+            log_key: 'neg.nce_score',
+            normalize_y: true,
+            reduction: 'none',
+          },  //This loss can be different from the main loss // change this
+          {
+            type: 'multi-label-bce',
+            reduction: 'none',
+            log_key: 'bce',
+          },
+        ],
+        loss_weights: [dvn_score_loss_weight, cross_entropy_loss_weight],
+        reduction: 'mean',
+      },
+    },
+    oracle_value_function: { type: 'per-instance-f1', differentiable: false },
+    score_nn: {
+      type: 'multi-label-classification',
+      task_nn: {
+        type: 'multi-label-classification',
+        feature_network: {
+          input_dim: num_input_features,
+          num_layers: ff_linear_layers,
+          activations: ([ff_activation for i in std.range(0, ff_linear_layers - 2)] + [ff_activation]),
+          hidden_dims: ff_hidden,
+          dropout: ([ff_dropout for i in std.range(0, ff_linear_layers - 2)] + [0]),
+        },
+        label_embeddings: {
+          embedding_dim: ff_hidden,
+          vocab_namespace: 'labels',
+        },
+      },
+      global_score: {
+        type: 'multi-label-feedforward',
+        feedforward: {
+          input_dim: num_labels,
+          num_layers: 1,
+          activations: ff_activation,
+          hidden_dims: global_score_hidden_dim,
+        },
+      },
+    },
+    loss_fn: {
+      type: 'multi-label-nce-ranking-with-discrete-sampling',
+      log_key: 'nce',
+      num_samples: 10,
+      sign: '+',
+    },
+    initializer: {
+      regexes: [
+        //[@'.*_feedforward._linear_layers.0.weight', {type: 'normal'}],
+        [@'.*_linear_layers.*weight', (if std.member(['tanh', 'sigmoid'], ff_activation) then { type: 'xavier_uniform', gain: gain } else { type: 'kaiming_uniform', nonlinearity: 'relu' })],
+        [@'.*linear_layers.*bias', { type: 'zero' }],
+      ],
+    },
+  },
+  data_loader: {
+    shuffle: true,
+    batch_size: 32,
+  },
+  trainer: {
+    type: 'gradient_descent_minimax',
+    num_epochs: if test == '1' then 10 else 300,
+    grad_norm: { task_nn: 10.0 },
+    patience: 20,
+    validation_metric: '+fixed_f1',
+    cuda_device: std.parseInt(cuda_device),
+    learning_rate_schedulers: {
+      task_nn: {
+        type: 'reduce_on_plateau',
+        factor: 0.5,
+        mode: 'max',
+        patience: 5,
+        verbose: true,
+      },
+    },
+    optimizer: {
+      optimizers: {
+        task_nn:
+          {
+            lr: 0.001,
+            weight_decay: ff_weight_decay,
+            type: 'adamw',
+          },
+        score_nn: {
+          lr: 0.005,
+          weight_decay: ff_weight_decay,
+          type: 'adamw',
+        },
+      },
+    },
+    checkpointer: {
+      keep_most_recent_by_count: 1,
+    },
+    callbacks: [
+      'track_epoch_callback',
+      'slurm',
+    ] + (
+      if use_wandb then [
+        {
+          type: 'wandb_allennlp',
+          sub_callbacks: [{ type: 'log_best_validation_metrics', priority: 100 }],
+        },
+      ]
+      else []
+    ),
+    inner_mode: 'score_nn',
+    num_steps: { task_nn: task_nn_steps, score_nn: score_nn_steps },
+  },
+}

--- a/sweep_configs/multilabel_classification/v2.5/delicious_refined_dvn_tasknn_sampled_reverse.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/delicious_refined_dvn_tasknn_sampled_reverse.yaml
@@ -1,0 +1,129 @@
+name: delicious_dvn_tasknn_samples_reverse
+description: "Train tasknn using cross-entropy and dvn score loss (v(f(x),y)). We will have only one sampler--tasknn continuous samples--to train scoreNN. The network parameters are from structure_prediction_baselines/7tvr5xhg"
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_samples_reverse.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,model=dvn,sampler=inference_net_continuous_samples,dataset=delicious,inference_module=inference_net,inference_module=tasknn,sampler=tasknn_contiuous_samples,ref=7tvr5xhg"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.dataset_name:
+    value: 'delicious'
+  env.cross_entropy_loss_weight:
+    value: 1.0
+  env.dvn_score_loss_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.ff_dropout_10x:
+    distribution: q_uniform
+    min: 2.5
+    max: 5.49
+    # value: 0.5
+  env.ff_hidden:
+    distribution: q_uniform
+    min: 200
+    max: 500
+    q: 100  
+    # value: 400
+  env.ff_linear_layers:
+    distribution: q_uniform
+    min: 1.5
+    max: 3.49
+    q: 1
+  env.ff_weight_decay:
+    value: 0.00001
+  env.global_score_hidden_dim:
+    distribution: q_uniform
+    min: 100
+    max: 400
+    q: 100
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -9
+    max: -4.5 
+  trainer.optimizer.optimizers.score_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  # trainer.num_steps.score_nn:
+  #   distribution: q_uniform
+  #   min: 3
+  #   max: 11
+  #   q: 3
+  env.score_nn_steps:
+    distribution: q_uniform
+    min: 0
+    max: 11.99
+    q: 3
+  env.task_nn_steps: # instead of trainer.num_steps.task_nn
+    value: 1
+  model.inference_module.num_samples:
+    distribution: q_log_uniform
+    q: 5 # 1, 5, 10, 15, ..., 50
+    min: 0 # ln(1)
+    max: 3.92 # ln(50)
+  model.inference_module.std:
+    distribution: log_uniform 
+    min: -6.9 # ln(0.001)
+    max: 1.6  # ln(5)
+  # env.ff_dropout_10x:
+  #   distribution: q_uniform
+  #   min: 1
+  #   max: 5
+  #   # value: 0.5
+  # env.ff_hidden:
+  #   distribution: q_uniform
+  #   min: 200
+  #   max: 500
+  #   q: 100  
+  #   # value: 400
+  # env.ff_linear_layers:
+  #   distribution: q_uniform
+  #   min: 1
+  #   max: 5
+  #   q: 1  
+  #   # value: 2
+  # env.ff_weight_decay:
+  #   value: 0.00001
+  # env.global_score_hidden_dim:
+  #   distribution: q_uniform
+  #   min: 100
+  #   max: 400
+  #   q: 100
+  # trainer.optimizer.optimizers.task_nn.lr:
+  #   distribution: log_uniform
+  #   min: -11.5
+  #   max: -4.5 
+  # trainer.optimizer.optimizers.score_nn.lr:
+  #   distribution: log_uniform
+  #   min: -11.5
+  #   max: -4.5
+  # trainer.num_steps.score_nn:
+  #   distribution: q_uniform
+  #   min: 3
+  #   max: 11
+  #   q: 3
+  # env.stopping_criteria: # instead of trainer.num_steps.task_nn
+  #   value: 1
+  # model.inference_module.num_samples:
+  #   distribution: q_log_uniform
+  #   q: 5 # 1, 5, 10, 15, ..., 50
+  #   min: 0 # ln(1)
+  #   max: 3.92 # ln(50)
+  # model.inference_module.std:
+  #   distribution: log_uniform 
+  #   min: -6.9 # ln(0.001)
+  #   max: 1.6  # ln(5)

--- a/sweep_configs/multilabel_classification/v2.5/delicious_refined_nce_cont_minus_tasknn_reverse.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/delicious_refined_nce_cont_minus_tasknn_reverse.yaml
@@ -1,0 +1,83 @@
+name: delicious_nce_cont_minus_tasknn_reverse
+description: "Train tasknn using cross-entropy and  score loss (v(f(x),y)). The score-nn will be trained using NCE with a - sign (score+ln Pn). The samples are taken as continuous samples by adding gaussian noise to the tasknn output logits"
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/gendata_nce_cont_tasknn_reverse.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,score_nn_loss=nce,sampler=inference_net_continuous_samples,dataset=delicious,inference_module=inference_net,inference_module=tasknn,inference_module_loss=bce+score,sampler=tasknn_contiuous_samples,ref=7tvr5xhg"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.dataset_name:
+    value: 'delicious'
+  env.cross_entropy_loss_weight:
+    value: 1.0
+  env.dvn_score_loss_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.ff_dropout_10x:
+    distribution: q_uniform
+    min: 1.5
+    max: 5.49
+    # value: 0.5
+  env.ff_hidden:
+    distribution: q_uniform
+    min: 200
+    max: 500
+    q: 100  
+    # value: 400
+  env.ff_linear_layers:
+    distribution: q_uniform
+    min: 1.5
+    max: 3.49
+    q: 1
+  env.ff_weight_decay:
+    value: 0.00001
+  env.global_score_hidden_dim:
+    distribution: q_uniform
+    min: 100
+    max: 400
+    q: 100
+    # value: 200
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5 
+  trainer.optimizer.optimizers.score_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  env.score_nn_steps:
+    distribution: q_uniform
+    min: 0
+    max: 11.99
+    q: 3
+  env.task_nn_steps: # instead of trainer.num_steps.task_nn
+    value: 1
+    # distribution: q_uniform
+    # q: 5 # 1, 5, 10 --> manual handling in the jsonnet.
+    # min: 0
+    # max: 10
+  model.loss_fn.num_samples:
+    distribution: q_uniform
+    q: 20 # 10, 25, ..., 50
+    min: 20 # ln(10)
+    max: 100 # ln(50)
+  model.loss_fn.sign:
+    value: "-"
+  model.loss_fn.std:
+    distribution: log_uniform 
+    min: -6.9 # ln(0.001)
+    max: 1.6  # ln(5)

--- a/sweep_configs/multilabel_classification/v2.5/delicious_refined_nce_discrete_minus_tasknn_reverse.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/delicious_refined_nce_discrete_minus_tasknn_reverse.yaml
@@ -1,0 +1,87 @@
+name: delicious_nce_discrete_minus_tasknn_reverse
+description: "Train tasknn using cross-entropy and  score loss (v(f(x),y)). The score-nn will be trained using NCE with a - sign (score-ln Pn). The samples are taken as discrete samples from the tasknn output."
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/gendata_nce_discrete_tasknn_reverse.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,model=dvn,sampler=inference_net_continuous_samples,dataset=delicious,inference_module=inference_net,inference_module=tasknn,sampler=tasknn_contiuous_samples"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.dataset_name:
+    value: 'delicious'
+  env.cross_entropy_loss_weight:
+    value: 1.0
+  env.dvn_score_loss_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.ff_dropout_10x:
+    distribution: q_uniform
+    min: 1.5
+    max: 5.49
+    # value: 0.5
+  env.ff_hidden:
+    distribution: q_uniform
+    min: 200
+    max: 500
+    q: 100  
+    # value: 400
+  env.ff_linear_layers:
+    distribution: q_uniform
+    min: 1.5
+    max: 3.49
+    q: 1
+  env.ff_linear_layers:
+    distribution: q_uniform
+    min: 0.5
+    max: 5.49
+    q: 1  
+  env.ff_weight_decay:
+    value: 0.00001
+  env.global_score_hidden_dim:
+    distribution: q_uniform
+    min: 100
+    max: 400
+    q: 100
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5 
+  trainer.optimizer.optimizers.score_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  env.score_nn_steps:
+    distribution: q_uniform
+    min: 0
+    max: 11.99
+    q: 3
+  env.task_nn_steps: # instead of trainer.num_steps.task_nn
+    value: 1
+    # distribution: q_uniform
+    # q: 5 # 1, 5, 10 --> manual handling in the jsonnet.
+    # min: 0
+    # max: 10
+  model.loss_fn.num_samples:
+    distribution: q_uniform
+    q: 20 # 10, 25, ..., 50
+    min: 20 # ln(10)
+    max: 80 # ln(50)
+  model.loss_fn.sign:
+    value: "-"
+  #model.loss_fn.std:
+  #  distribution: log_uniform 
+  #  min: -6.9 # ln(0.001)
+  #  max: 1.6  # ln(5)

--- a/sweep_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_reverse.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_reverse.yaml
@@ -1,0 +1,74 @@
+name: genbase_dvn_tasknn_reverse
+description: "Train tasknn using cross-entropy and dvn score loss (v(f(x),y)). We will have only one sampler--tasknn continuous--to train scoreNN. The network parameters are from structure_prediction_baselines/7tvr5xhg"
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_reverse.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,model=dvn,sampler=inference_net,dataset=genbase,inference_module=inference_net,inference_module=tasknn,sampler=tasknn,ref=7tvr5xhg"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.dataset_name:
+    value: 'genbase'
+  env.cross_entropy_loss_weight:
+    value: 1.0
+  env.dvn_score_loss_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.ff_dropout_10x:
+    distribution: q_uniform
+    min: 0.5 # 1
+    max: 5.49 # 5
+    # value: 0.5 # bibtex
+  env.ff_hidden:
+    distribution: q_uniform
+    min: 50 # 100
+    max: 549 # 500
+    q: 100  
+    # value: 400 # bibtex
+  env.ff_linear_layers:
+    distribution: q_uniform
+    min: 0.5  # 1
+    max: 5.49 # 5
+    q: 1  
+    # value: 2 # bibtex
+  env.ff_weight_decay:
+    value: 0.00001
+  env.global_score_hidden_dim:
+    distribution: q_uniform
+    min: 50  #100
+    max: 449 #400
+    q: 100
+    # value: 200 # bibtex  
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -12.5
+    max: -4.5 
+  trainer.optimizer.optimizers.score_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  env.score_nn_steps:
+    distribution: q_uniform
+    min: 0
+    max: 11.99
+    q: 3
+  env.task_nn_steps: # instead of trainer.num_steps.task_nn
+    value: 1
+    # distribution: q_uniform
+    # q: 5 # 1, 5, 10 --> manual handling in the jsonnet.
+    # min: 0
+    # max: 10
+

--- a/sweep_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_sampled_reverse.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_sampled_reverse.yaml
@@ -1,0 +1,82 @@
+name: genbase_dvn_tasknn_samples_reverse
+description: "Train tasknn using cross-entropy and dvn score loss (v(f(x),y)). We will have only one sampler--tasknn continuous samples--to train scoreNN. The network parameters are from structure_prediction_baselines/7tvr5xhg"
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/gendata_dvn_tasknn_samples_reverse.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,model=dvn,sampler=inference_net_continuous_samples,dataset=genbase,inference_module=inference_net,inference_module=tasknn,sampler=tasknn_contiuous_samples,ref=7tvr5xhg"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.dataset_name:
+    value: 'genbase'
+  env.cross_entropy_loss_weight:
+    value: 1.0
+  env.dvn_score_loss_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.ff_dropout_10x:
+    distribution: q_uniform
+    min: 0.5 # 1
+    max: 5.49 # 5
+    # value: 0.5 # bibtex
+  env.ff_hidden:
+    distribution: q_uniform
+    min: 50 # 100
+    max: 549 # 500
+    q: 100  
+    # value: 400 # bibtex
+  env.ff_linear_layers:
+    distribution: q_uniform
+    min: 0.5  # 1
+    max: 5.49 # 5
+    q: 1  
+    # value: 2 # bibtex
+  env.ff_weight_decay:
+    value: 0.00001
+  env.global_score_hidden_dim:
+    distribution: q_uniform
+    min: 50  #100
+    max: 449 #400
+    q: 100
+    # value: 200 # bibtex  
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -12.5
+    max: -4.5 
+  trainer.optimizer.optimizers.score_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  env.score_nn_steps:
+    distribution: q_uniform
+    min: 0
+    max: 11.99
+    q: 3
+  env.task_nn_steps: # instead of trainer.num_steps.task_nn
+    value: 1
+    # distribution: q_uniform
+    # q: 5 # 1, 5, 10 --> manual handling in the jsonnet.
+    # min: 0
+    # max: 10
+  model.inference_module.num_samples:
+    distribution: q_log_uniform
+    q: 5 # 1, 5, 10, 15, ..., 50
+    min: 0 # ln(1)
+    max: 3.92 # ln(50)
+  model.inference_module.std:
+    distribution: log_uniform 
+    min: -6.9 # ln(0.001)
+    max: 1.6  # ln(5)

--- a/sweep_configs/multilabel_classification/v2.5/gendata_nce_cont_minus_tasknn_reverse.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/gendata_nce_cont_minus_tasknn_reverse.yaml
@@ -1,0 +1,80 @@
+name: delicious_nce_cont_minus_tasknn_reverse
+description: "Train tasknn using cross-entropy and  score loss (v(f(x),y)). The score-nn will be trained using NCE with a - sign (score+ln Pn). The samples are taken as continuous samples by adding gaussian noise to the tasknn output logits"
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/gendata_nce_cont_tasknn_reverse.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,score_nn_loss=nce,sampler=inference_net_continuous_samples,dataset=delicious,inference_module=inference_net,inference_module=tasknn,inference_module_loss=bce+score,sampler=tasknn_contiuous_samples,ref=7tvr5xhg"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.dataset_name:
+    value: 'delicious'
+  env.cross_entropy_loss_weight:
+    value: 1.0
+  env.dvn_score_loss_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.ff_dropout_10x:
+    distribution: q_uniform
+    min: 0.5 # 1
+    max: 5.49 # 5
+    # value: 0.5 # bibtex
+  env.ff_hidden:
+    distribution: q_uniform
+    min: 50 # 100
+    max: 549 # 500
+    q: 100  
+    # value: 400 # bibtex
+  env.ff_linear_layers:
+    distribution: q_uniform
+    min: 0.5  # 1
+    max: 5.49 # 5
+    q: 1  
+    # value: 2 # bibtex
+  env.ff_weight_decay:
+    value: 0.00001
+  env.global_score_hidden_dim:
+    distribution: q_uniform
+    min: 50  #100
+    max: 449 #400
+    q: 100
+    # value: 200 # bibtex
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -12.5
+    max: -4.5 
+  trainer.optimizer.optimizers.score_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  env.score_nn_steps:
+    distribution: q_uniform
+    min: 0
+    max: 11.99
+    q: 3
+  env.task_nn_steps: # instead of trainer.num_steps.task_nn
+    value: 1
+  model.loss_fn.num_samples:
+    distribution: q_uniform
+    q: 20 # 10, 25, ..., 50
+    min: 20 # ln(10)
+    max: 100 # ln(50)
+  model.loss_fn.sign:
+    value: "-"
+  model.loss_fn.std:
+    distribution: log_uniform 
+    min: -6.9 # ln(0.001)
+    max: 1.6  # ln(5)

--- a/sweep_configs/multilabel_classification/v2.5/gendata_nce_discrete_minus_tasknn_reverse.yaml
+++ b/sweep_configs/multilabel_classification/v2.5/gendata_nce_discrete_minus_tasknn_reverse.yaml
@@ -1,0 +1,84 @@
+name: delicious_nce_discrete_minus_tasknn_reverse
+description: "Train tasknn using cross-entropy and  score loss (v(f(x),y)). The score-nn will be trained using NCE with a - sign (score-ln Pn). The samples are taken as discrete samples from the tasknn output."
+program: allennlp
+command:
+- ${program}
+- train_with_wandb
+- model_configs/multilabel_classification/v2.5/gendata_nce_discrete_tasknn_reverse.jsonnet
+- --include-package=structured_prediction_baselines
+- --wandb_tags="task=mlc,model=dvn,sampler=inference_net_continuous_samples,dataset=delicious,inference_module=inference_net,inference_module=tasknn,sampler=tasknn_contiuous_samples"
+- ${args}
+- --file-friendly-logging
+method: bayes
+metric:
+  goal: maximize
+  name: "validation/best_fixed_f1"
+
+early_terminate:
+  type: hyperband
+  min_iter: 20
+
+parameters:
+  env.dataset_name:
+    value: 'delicious'
+  env.cross_entropy_loss_weight:
+    value: 1.0
+  env.dvn_score_loss_weight:
+    distribution: log_uniform
+    min: -6.9
+    max: 2.3
+  env.ff_dropout_10x:
+    distribution: q_uniform
+    min: 0.5 # 1
+    max: 5.49 # 5
+    # value: 0.5 # bibtex
+  env.ff_hidden:
+    distribution: q_uniform
+    min: 50 # 100
+    max: 549 # 500
+    q: 100  
+    # value: 400 # bibtex
+  env.ff_linear_layers:
+    distribution: q_uniform
+    min: 0.5
+    max: 5.49
+    q: 1  
+    # data: genbase
+    # distribution: q_uniform
+    # min: 0.5  # 0.5-1.49999 --> 1
+    # max: 2.49 # 0.5-2.49999 --> 2
+    # q: 1  
+  env.ff_weight_decay:
+    value: 0.00001
+  env.global_score_hidden_dim:
+    distribution: q_uniform
+    min: 50  #100
+    max: 449 #400
+    q: 100
+    # value: 200 # bibtex
+  trainer.optimizer.optimizers.task_nn.lr:
+    distribution: log_uniform
+    min: -12.5
+    max: -4.5 
+  trainer.optimizer.optimizers.score_nn.lr:
+    distribution: log_uniform
+    min: -11.5
+    max: -4.5
+  env.score_nn_steps:
+    distribution: q_uniform
+    min: 0
+    max: 11.99
+    q: 3
+  env.task_nn_steps: # instead of trainer.num_steps.task_nn
+    value: 1
+    # distribution: q_uniform
+    # q: 5 # 1, 5, 10 --> manual handling in the jsonnet.
+    # min: 0
+    # max: 10
+  model.loss_fn.num_samples:
+    distribution: q_uniform
+    q: 20 # 10, 25, ..., 50
+    min: 20 # ln(10)
+    max: 80 # ln(50)
+  model.loss_fn.sign:
+    value: "-"


### PR DESCRIPTION

1.     Added sweeps and configs so any data (general data, in short, 'gendata') can be handeled. 
2. Also made scoreNN & taskNN step to include 1 in the sweep (jsonnet change). 
3. Made the q_uniform probabilities to be equally likely for each discrete number. (e.g. rather than min:1, max:5 --> min:0.5, max:5.49)
4. Added sweep configs for delicious that works with general-data jsonnet (gendata*.jsonnet). Refined sweep looks at layers 2, 3 and the dropouts higher than the plain search. 