### PR TITLE
Made the loss functions to always call normalize() function whenever normalize_y=True

### DIFF
--- a/structured_prediction_baselines/modules/loss/dvn.py
+++ b/structured_prediction_baselines/modules/loss/dvn.py
@@ -83,8 +83,6 @@ class DVNLoss(Loss):
         # score_nn always expects y to be normalized
         # do the normalization based on the task
 
-        if self.normalize_y:
-            y_hat = self.normalize(y_hat)
         predicted_score = self.score_nn(
             x, y_hat, buffer, **kwargs
         )  # (batch, num_samples)
@@ -166,11 +164,7 @@ class DVNLossCostAugNet(Loss):
         )  # purely for typing, no runtime effect
         # score_nn always expects y to be normalized
         # do the normalization based on the task
-
-        if self.normalize_y:
-            y_hat = self.normalize(y_hat)
-            y_hat_extra = self.normalize(y_hat_extra)
-
+        
         predicted_score = self.score_nn(
             x, y_hat, buffer, **kwargs
         )  # (batch, num_samples)
@@ -256,10 +250,7 @@ class DVNScoreLoss(Loss):
 
         # score_nn always expects y to be normalized
         # do the normalization based on the task
-
-        if self.normalize_y:
-            y_hat = self.normalize(y_hat)
-
+        
         predicted_score = self.score_nn(
             x, y_hat, buffer, **kwargs
         )  # (batch, num_samples)
@@ -324,13 +315,7 @@ class DVNScoreCostAugNet(Loss):
         # y_hat shape (batch, num_samples, ...)
         self.score_nn = cast(
             ScoreNN, self.score_nn
-        )  # purely for typing, no runtime effect
-
-        # score_nn always expects y to be normalized
-        # do the normalization based on the task
-
-        if self.normalize_y:
-            y_hat = self.normalize(y_hat)
+        )  # purely for typing, no runtime effect 
 
         predicted_score_infnet = self.score_nn(
             x, y_hat, buffer, **kwargs

--- a/structured_prediction_baselines/modules/loss/inference_net_loss.py
+++ b/structured_prediction_baselines/modules/loss/inference_net_loss.py
@@ -169,11 +169,7 @@ class MarginBasedLoss(Loss):
 
         if y_cost_aug is None:
             y_cost_aug = torch.zeros_like(y_hat)
-        elif self.normalize_y:  # y_cost_aug is not None
-            y_cost_aug = self.normalize(y_cost_aug)
 
-        if self.normalize_y:
-            y_hat = self.normalize(y_hat)
         ground_truth_score = self.score_nn(
             x, labels.to(dtype=y_hat.dtype), buffer
         )

--- a/structured_prediction_baselines/modules/loss/loss.py
+++ b/structured_prediction_baselines/modules/loss/loss.py
@@ -61,6 +61,12 @@ class Loss(LoggingMixin, torch.nn.Module, Registrable):
         buffer: Dict,
         **kwargs: Any,
     ) -> torch.Tensor:
+
+        if self.normalize_y:
+            y_hat = self.normalize(y_hat)
+            if y_hat_extra is not None:
+                y_hat_extra = self.normalize(y_hat_extra)
+
         loss_unreduced = self._forward(
             x, labels, y_hat, y_hat_extra, buffer, **kwargs
         )

--- a/structured_prediction_baselines/modules/loss/multilabel_classification/ovf.py
+++ b/structured_prediction_baselines/modules/loss/multilabel_classification/ovf.py
@@ -19,8 +19,5 @@ class MultiLabelOVFLoss(Loss):
     ) -> torch.Tensor:
         assert labels is not None
         assert self.oracle_value_function is not None
-
-        if self.normalize_y:
-            y_hat = self.normalize(y_hat)
-
+        
         return -self.oracle_value_function(labels, y_hat)  # (batch,)


### PR DESCRIPTION
Before, although components `self.normalize_y `& `normalize()` were there, there was no checking of whether `normalize()` is actually called or implemented when we set flag `self.normalize_y=True`.
Made a change in the base class to do normalization if `self.normalize_y=True` so that if `normalize()`  is not implemented the code will return errors.