### PR TITLE
Receive one more output from GBI sampler

### DIFF
--- a/structured_prediction_baselines/models/multilabel_classification.py
+++ b/structured_prediction_baselines/models/multilabel_classification.py
@@ -147,9 +147,9 @@ class MultilabelClassificationWithScoreNNEvaluation(MultilabelClassification):
         random_samples = self.get_samples(y_hat_n, random=True)
 
         # call evaluation_module on distribution and random samples
-        tasknn_gbi_samples, _ = self.evaluation_module(x, labels, buffer, init_samples=tasknn_samples, index=0)
+        tasknn_gbi_samples, _, loss_ = self.evaluation_module(x, labels, buffer, init_samples=tasknn_samples, index=0)
         self.tasknn_samples_f1(self.squeeze_y(tasknn_gbi_samples), labels)
-        random_gbi_samples, _ = self.evaluation_module(x, labels, buffer, init_samples=random_samples, index=1)
+        random_gbi_samples, _, loss_ = self.evaluation_module(x, labels, buffer, init_samples=random_samples, index=1)
         self.random_samples_f1(self.squeeze_y(random_gbi_samples), labels)
 
     def get_true_metrics(self, reset: bool = False) -> Dict[str, float]:


### PR DESCRIPTION
The Sampler sends out 3 outputs but the old GBI sampler was sending only two. After fixing this, the evaluation module fails. 